### PR TITLE
[WIP] Kubernetes support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 .vscode
 .python-version
 venv
+
+Chart.lock
+*.tgz
+helm/charts

--- a/deployment/kubernetes/deployment.md
+++ b/deployment/kubernetes/deployment.md
@@ -1,0 +1,22 @@
+
+# Deployment on Kubernetes
+
+## Prerequisites
+- Connection to cluster (Link to minikube)
+- Specify minimum version of kubernetes
+- Using helm 3
+
+## Install commands
+TODO
+
+## Configuration of values.yaml
+TODO
+
+## Connect to metrics and observe your data
+
+TODO
+
+## Troubleshooting
+
+If you have any problems with running above please join our [Slack](https://join.slack.com/t/redatahq/shared_invite/zt-lrp4khvb-kIS6ct4WzJTy~JNVzwB5yw)
+We will be happy to help! :)

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,11 +6,9 @@ dependencies:
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.2.0
-- name: airflow-stable
+- name: airflow
   repository: https://airflow-helm.github.io/charts
   version: 7.16.0  # Uses version 1.10.12
-- name: airflow-stable
-  repository: https://airflow-helm.github.io/charts
-  version: 7.16.0  # Uses version 1.10.12
-- name: wener/postgres-operator
+- name: postgres-operator
   repository: https://charts.wener.tech/
+  version: 1.6.1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+description: A chart for redata
+name: redata
+version: 0.0.10-alfa
+dependencies:
+- name: grafana
+  repository: https://grafana.github.io/helm-charts
+  version: 6.2.0
+- name: airflow-stable
+  repository: https://airflow-helm.github.io/charts
+  version: 7.16.0  # Uses version 1.10.12
+- name: airflow-stable
+  repository: https://airflow-helm.github.io/charts
+  version: 7.16.0  # Uses version 1.10.12
+- name: wener/postgres-operator
+  repository: https://charts.wener.tech/

--- a/helm/templates/redata.yaml
+++ b/helm/templates/redata.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redata
+  labels:
+    app: redata
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redata
+  template:
+    metadata:
+      labels:
+        app: redata
+    spec:
+      containers:
+      - name: redata
+        image: redatateam/redata:0.0.10-alfa

--- a/scripts/build-helm.sh
+++ b/scripts/build-helm.sh
@@ -1,0 +1,8 @@
+readonly VERSION=$(git describe --tags)
+
+helm3 dependency build helm
+
+# TODO:
+# Pass version into the Chart.yaml
+# Build the chart: helm3 package --version "$VERSION" helm
+# Look into where to host the charts??


### PR DESCRIPTION
Here's a basic skeleton of what I indeed to do:
1. [helm](https://helm.sh/docs/) will package up the application including existing charts where possible and some custom templates to ensure everything works together.
2. An entry to `deployment/kubernetes` to outline how to install this in an existing cluster.
3. Finish the build script
4. Think more on hosting the charts: (Artifact Hub vs [Github Pages](https://medium.com/@mattiaperi/create-a-public-helm-chart-repository-with-github-pages-49b180dbb417)

Assumptions:
- `redata` and the `airflow` instance can use the same postgres instance with 2 different databases, one with the timescaleDB enabled. 
- `redata` pushes to `timescaleDBa` and Grafana reads from that.

All comments and questions welcome
