### PR TITLE
Fix typo in metrics

### DIFF
--- a/docs/docs/reference/config.md
+++ b/docs/docs/reference/config.md
@@ -54,15 +54,15 @@ vars:
         - avg
         - stddev
         - variance
-        - count_nulls
+        - nulls_count
         - diff # my own custom metric
         
       text:
         - min_length
         - max_length
         - avg_length
-        - count_nulls
-        - count_missing
+        - nulls_count
+        - missing_count
 
   # (optional) global z_score threshold to use for alerting
   # usually keeping default will be enough


### PR DESCRIPTION
## What
Count_nulls and count_missing are renamed with re_data 0.3.0

## How
Using the new names in the doc for the feature to work
