### PR TITLE
delete ui and docs deployment on branch deletion

### DIFF
--- a/.github/workflows/generate-ui.yml
+++ b/.github/workflows/generate-ui.yml
@@ -1,6 +1,6 @@
 name: Generate UI for toy_shop project
 
-on: push
+on: [push, delete]
 
 env:
   DBT_PROFILES_DIR: ${{ github.workspace }}/getting_started/toy_shop

--- a/.github/workflows/generate-ui.yml
+++ b/.github/workflows/generate-ui.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Set the TOY_SHOP_SCHEMA environment variable
         run: |
-          echo "TOY_SHOP_SCHEMA=toy_shop_${GITHUB_REF_SLUG//-/_}" >> $GITHUB_ENV
+          echo "TOY_SHOP_SCHEMA=toy_shop_${GITHUB_REF_SLUG//[^[:alnum:]]/_}" >> $GITHUB_ENV
 
       - name: Print TOY_SHOP_SCHEMA
         run: |
@@ -243,7 +243,7 @@ jobs:
 
       - name: Set the TOY_SHOP_SCHEMA environment variable
         run: |
-          echo "TOY_SHOP_SCHEMA=toy_shop_${GITHUB_EVENT_REF_SLUG//-/_}" >> $GITHUB_ENV
+          echo "TOY_SHOP_SCHEMA=toy_shop_${GITHUB_EVENT_REF_SLUG//[^[:alnum:]]/_}" >> $GITHUB_ENV
 
       - name: Print TOY_SHOP_SCHEMA
         run: |

--- a/.github/workflows/generate-ui.yml
+++ b/.github/workflows/generate-ui.yml
@@ -277,11 +277,11 @@ jobs:
       - name: Delete generated documentation and observability UI for branch
         working-directory: ./getting_started/toy_shop
         run: |
-          rm -rf ${{env.GITHUB_REF_SLUG}}
-          rm -rf ui-${{env.GITHUB_REF_SLUG}}
-          rm -rf ui-${{env.GITHUB_REF_SLUG}}-snowflake
-          rm -rf ui-${{env.GITHUB_REF_SLUG}}-bigquery
-          rm -rf ui-${{env.GITHUB_REF_SLUG}}-redshift
+          rm -rf ${{env.GITHUB_EVENT_REF_SLUG}}
+          rm -rf ui-${{env.GITHUB_EVENT_REF_SLUG}}
+          rm -rf ui-${{env.GITHUB_EVENT_REF_SLUG}}-snowflake
+          rm -rf ui-${{env.GITHUB_EVENT_REF_SLUG}}-bigquery
+          rm -rf ui-${{env.GITHUB_EVENT_REF_SLUG}}-redshift
 
       - name: Update github pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/generate-ui.yml
+++ b/.github/workflows/generate-ui.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   generate-ui:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     services:
       postgres:
         image: postgres

--- a/.github/workflows/generate-ui.yml
+++ b/.github/workflows/generate-ui.yml
@@ -277,6 +277,7 @@ jobs:
 
       - name: Delete generated documentation and observability UI for branch
         run: |
+          ls
           rm -rf ${{env.GITHUB_EVENT_REF_SLUG}}
           rm -rf ui-${{env.GITHUB_EVENT_REF_SLUG}}
           rm -rf ui-${{env.GITHUB_EVENT_REF_SLUG}}-snowflake

--- a/.github/workflows/generate-ui.yml
+++ b/.github/workflows/generate-ui.yml
@@ -276,7 +276,6 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
 
       - name: Delete generated documentation and observability UI for branch
-        working-directory: ./getting_started/toy_shop
         run: |
           rm -rf ${{env.GITHUB_EVENT_REF_SLUG}}
           rm -rf ui-${{env.GITHUB_EVENT_REF_SLUG}}


### PR DESCRIPTION
## What
Every branch created builds a docs and UI folder specific to that branch in `gh-pages`. Over time multiple deployments have accumulated making the git repository heavier. Once a feature is completed, we need to eliminate the corresponding deployments, and we can achieve that by listening to the `delete` branch event.

## How
On branch deletion, we delete folders generated for docs and observability UI and push afresh to gh-pages branch.
