### PR TITLE
Edit documentations on configuration and test history

### DIFF
--- a/docs/docs/reference/config.mdx
+++ b/docs/docs/reference/config.mdx
@@ -35,7 +35,7 @@ Additionaly `re_data` gives the least prority to vars configuration in `re_data:
       re_data_monitored=true,
       re_data_time_filter='creation_time',
       re_data_columns=['amount', 'status'],
-      re_data_metrics={'table': ['orders_obove_100'], 'column': { 'status': 'distinct_values' }}
+      re_data_metrics={'table': ['orders_obove_100'], 'column': { 'status': ['distinct_values'] }}
     )
 }}
 

--- a/docs/docs/reference/tests/history.md
+++ b/docs/docs/reference/tests/history.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 re_data adds dbt macros which make it possible to save test history to your data warehouse & later on investigate them with our reliability UI.
 
 ## on-run-end
-To start saving tests you just need to call re_data `save_test_history` macro in `on-run-end` hook. You can do it by adding the code below into your `dbt_prroject.yml`. In case of having some other hooks existing already you just need to add this as an item into the list.
+To start saving tests you just need to call re_data `save_test_history` macro in `on-run-end` hook. You can do it by adding the code below into your `dbt_project.yml`. In case of having some other hooks existing already you just need to add this as an item into the list.
 
 ```yml dbt_project.yml
 


### PR DESCRIPTION
## What
- `Configuration`, `re_data_metrics` especially at column on current documentation missing []
- `Test History`, `dbt_prroject.yml`

## How
- For `Configuration`, `re_data_metrics` especially on column should added bracket [ ]
- edit typo type from `dbt_prroject.yml` to `dbt_project.yml`