### PR TITLE
add target and port args to relevant commands

### DIFF
--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -26,6 +26,7 @@ def add_dbt_flags(command_list, flags):
     for key, value in flags.items():
         if value:
             command_list.extend([f'--{key}', value])
+    print(' '.join(command_list))
 
 
 dbt_flags = [
@@ -99,7 +100,7 @@ def init(project_name):
 def detect(**kwargs):
     print(f"Detecting tables", "RUN")
 
-    run_list = ['dbt', 'run', '--models', 're_data_tables', 're_data_columns']
+    run_list = ['dbt', 'run', '--models', 're_data_columns', 're_data_monitored']
     add_dbt_flags(run_list, kwargs)
     completed_process = subprocess.run(run_list)
     completed_process.check_returncode()

--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -26,7 +26,6 @@ def add_dbt_flags(command_list, flags):
     for key, value in flags.items():
         if value:
             command_list.extend([f'--{key}', value])
-    print(command_list)
 
 
 dbt_flags = [

--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -94,7 +94,14 @@ def detect():
         Specify profile to be used with dbt.
     """
 )
-def run(start_date, end_date, interval, full_refresh, profile):
+@click.option(
+    '--target',
+    type=click.STRING,
+    help="""
+        Which target to load for the given profile.
+    """
+)
+def run(start_date, end_date, interval, full_refresh, profile, target):
     for_date = start_date
 
     time_grain, num_str = interval.split(':')
@@ -125,6 +132,8 @@ def run(start_date, end_date, interval, full_refresh, profile):
         
         if profile:
             run_list.extend(['--profile', profile])
+        if target:
+            run_list.extend(['--target', target])
 
         completed_process = subprocess.run(run_list)
         completed_process.check_returncode()
@@ -179,7 +188,14 @@ def notify():
         Specify profile to be used with dbt.
     """
 )
-def generate(start_date, end_date, interval, profile):
+@click.option(
+    '--target',
+    type=click.STRING,
+    help="""
+        Which target to load for the given profile.
+    """
+)
+def generate(start_date, end_date, interval, profile, target):
     start_date = str(start_date.date())
     end_date = str(end_date.date())
     args = {
@@ -190,6 +206,8 @@ def generate(start_date, end_date, interval, profile):
     command_list = ['dbt', 'run-operation', 'generate_overview', '--args', yaml.dump(args)]
     if profile:
         command_list.extend(['--profile', profile])
+    if target:
+        command_list.extend(['--target', target])
     completed_process = subprocess.run(command_list)
     completed_process.check_returncode()
 
@@ -208,12 +226,17 @@ def generate(start_date, end_date, interval, profile):
     )
 
 
+@click.option(
+    '--port',
+    type=click.INT,
+    default=8085,
+    help="Specify the port number for the UI server. Default is 8085"
+)
 @overview.command()
-def serve():
+def serve(port):
     serve_dir = os.path.join(os.getcwd(), 'target', 're_data')
     os.chdir(serve_dir)
 
-    port = 8085
     address = '0.0.0.0'
 
     httpd = TCPServer((address, port), SimpleHTTPRequestHandler)
@@ -266,7 +289,14 @@ def serve():
         Specify profile to be used with dbt.
     """
 )
-def slack(start_date, end_date, webhook_url, subtitle, profile):
+@click.option(
+    '--target',
+    type=click.STRING,
+    help="""
+        Which target to load for the given profile.
+    """
+)
+def slack(start_date, end_date, webhook_url, subtitle, profile, target):
     start_date = str(start_date.date())
     end_date = str(end_date.date())
     args = {
@@ -276,6 +306,8 @@ def slack(start_date, end_date, webhook_url, subtitle, profile):
     command_list = ['dbt', 'run-operation', 'export_alerts', '--args', yaml.dump(args)]
     if profile:
         command_list.extend(['--profile', profile])
+    if target:
+        command_list.extend(['--target', target])
     completed_process = subprocess.run(command_list)
     completed_process.check_returncode()
 


### PR DESCRIPTION
## What
re_data operations that run dbt commands are missing some important arguments to be passed. This PR allows the user to pass `--target` and `--port` arguments to relevant commands
