### PR TITLE
use shutil.copyfile to ensure it works across platforms and fix encoding

### DIFF
--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -231,9 +231,7 @@ def generate(start_date, end_date, interval, **kwargs):
 
     dbt_manifest_path = os.path.join(os.getcwd(), 'target', 'manifest.json')
     re_data_manifest = os.path.join(os.getcwd(), 'target', 're_data', 'dbt_manifest.json')
-    command_list = ['cp', dbt_manifest_path, re_data_manifest]
-    completed_process = subprocess.run(command_list)
-    completed_process.check_returncode()
+    shutil.copyfile(dbt_manifest_path, re_data_manifest)
 
     # todo: get target_path from dbt_project.yml
     target_file_path = os.path.join(os.getcwd(), 'target', 're_data', 'index.html')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 HERE = pathlib.Path(__file__).parent
 
 # The text of the README file
-README = (HERE / "README.md").read_text()
+README = (HERE / "README.md").read_text(encoding='utf-8')
 
 
 setup(


### PR DESCRIPTION
- Use copyfile from shutil package ensuring consistency across OS.
- Fix encoding in setup.py that avoids errors when building the python package locally on windows.
