### PR TITLE
Fix sources using `identifier` with same name breaking graph view

### DIFF
--- a/re_data_ui/src/utils/helpers.ts
+++ b/re_data_ui/src/utils/helpers.ts
@@ -104,6 +104,6 @@ export const appendToMapKey = (
 export const supportedResTypes = new Set(['source', 'model', 'seed']);
 
 export const generateModelId = (details: DbtNode | DbtSource): string => {
-  const { database, schema, name } = details;
-  return `${database}.${schema}.${name}`.toLowerCase();
+  const { database, schema, name, identifier } = details;
+  return `${database}.${schema}.${identifier || name}`.toLowerCase();
 };


### PR DESCRIPTION
This prevents duplicate model ids from being generated and breaking the graph if two separate sources pointing to a single schema (ie raw) use the same name

## What
Prevents duplicate model ids from being generated and breaking the graph

Example case where a duplicate model id would be generated:
```yaml
sources:
  schema: raw
  - name: salesforce
    tables:
      - name: contact
        identifier: sf_contact
        ...
  - name: hubspot
    tables:
      - name: contact
        identifier: hubspot_contact
        ...
```

## How
Use a short circuit op preferring identifier if it is available otherwise name
