### PR TITLE
Fix/Identifier Graph Issue - Added typeguard so eslint doesnt complain

### DIFF
--- a/re_data_ui/src/utils/helpers.ts
+++ b/re_data_ui/src/utils/helpers.ts
@@ -103,7 +103,22 @@ export const appendToMapKey = (
 
 export const supportedResTypes = new Set(['source', 'model', 'seed']);
 
-export const generateModelId = (details: DbtNode | DbtSource): string => {
-  const { database, schema, name, identifier } = details;
-  return `${database}.${schema}.${identifier || name}`.toLowerCase();
+type DbtNodeOrSource = DbtNode | DbtSource
+
+function isAliasedSource(node: DbtNodeOrSource): node is DbtSource {
+  if ((node as DbtSource).identifier) {
+    return true;
+  }
+  return false;
+}
+
+export const generateModelId = (details: DbtNodeOrSource): string => {
+  const { database, schema } = details;
+  let resolvedName: string;
+  if (isAliasedSource(details)) {
+    resolvedName = details.identifier;
+  } else {
+    resolvedName = details.name;
+  }
+  return `${database}.${schema}.${resolvedName}`.toLowerCase();
 };


### PR DESCRIPTION
Sorry for quick PR after the last, I replicated the build environment instead of using my own and saw a typescript error since the DbtNode interface doesn't have `identifier` as a prop. I added a typeguard which lints and compiles correctly and still resolves the issue. We verify if the node is in fact a source and has truthy identifier prop.

The below image is verification of issue resolution.

![image](https://user-images.githubusercontent.com/41213451/154371985-1abd5d3c-db54-45be-92c0-ddae25cc70c7.png)


## What
This resolves nodes with identifier breaking the graph view.

## How
Using a typeguard, we check for identifier and prefer that since that is the in database representation and unique within a schema

Resolves #226 
