### PR TITLE
fix dashes being replaced with undersore 

### DIFF
--- a/.github/workflows/generate-ui.yml
+++ b/.github/workflows/generate-ui.yml
@@ -64,7 +64,8 @@ jobs:
         working-directory: ./getting_started/toy_shop
         if: github.repository == 're-data/re-data'
         run: |
-          re_data notify slack --start-date 2021-01-01 --end-date 2021-01-11 --profile toy_shop_postgres --webhook-url ${{secrets.RE_DATA_TESTING_SLACK_ALERTS_WEBHOOK}} --subtitle="<https://github.com/${{ github.repository }}/commit/${{ github.sha }} |View Commit - (postgres)>"
+          re_data notify slack --start-date 2021-01-01 --end-date 2021-01-11 --profiles-dir ${{env.DBT_PROFILES_DIR}} --project-dir ./ \
+          --profile toy_shop_postgres --webhook-url ${{secrets.RE_DATA_TESTING_SLACK_ALERTS_WEBHOOK}} --subtitle="<https://github.com/${{ github.repository }}/commit/${{ github.sha }} |View Commit> - (postgres)"
 
       - uses: actions/setup-node@v2
         with:
@@ -179,7 +180,8 @@ jobs:
         working-directory: ./getting_started/toy_shop
         if: github.repository == 're-data/re-data'
         run: |
-          re_data notify slack --start-date 2021-01-01 --end-date 2021-01-11 --profile toy_shop_${{ matrix.database }} --webhook-url ${{secrets.RE_DATA_TESTING_SLACK_ALERTS_WEBHOOK}} --subtitle="<https://github.com/${{ github.repository }}/commit/${{ github.sha }} |View Commit> - (${{ matrix.database }})"
+          re_data notify slack --start-date 2021-01-01 --end-date 2021-01-11 --profiles-dir ${{env.DBT_PROFILES_DIR}} --project-dir ./ \
+          --profile toy_shop_${{ matrix.database }} --webhook-url ${{secrets.RE_DATA_TESTING_SLACK_ALERTS_WEBHOOK}} --subtitle="<https://github.com/${{ github.repository }}/commit/${{ github.sha }} |View Commit> - (${{ matrix.database }})"
 
       - uses: actions/setup-node@v2
         with:

--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -25,6 +25,7 @@ def add_options(options):
 def add_dbt_flags(command_list, flags):
     for key, value in flags.items():
         if value:
+            key = key.replace('_', '-')
             command_list.extend([f'--{key}', value])
     print(' '.join(command_list))
 


### PR DESCRIPTION
## What
When we collect arguments passed to click in `kwargs`, the dashes in the variable is replaced with underscore. This causes `profiles-dir` and `project-dir` to be read as `profiles_dir` and `project_dir` respectively.

## How
*Describe the solution*
