### PR TITLE
Update notify docs for incorrect end-date default

### DIFF
--- a/docs/docs/reference/cli/notify.md
+++ b/docs/docs/reference/cli/notify.md
@@ -19,7 +19,7 @@ Running this command would generate a slack message from the alerts re_data dete
 
 - Supported arguments:
     - start-date (default: today - 7 days) - start date of the period for which you want to generate alerts
-    - end-date (default: today - 7 days) - end date of the period for which you want to generate alerts
+    - end-date (default: today) - end date of the period for which you want to generate alerts
     - webhook-url - [incoming webhook](https://api.slack.com/messaging/webhooks) gotten from a slack app.
     - subtitle (optional) - extra markdown text passed to the generated message. Often used to add some more context to the message generated.
     - dbt-vars - This accepts a valid YAML dictionary as string which is passed down to the dbt command using [--vars](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/using-variables).


### PR DESCRIPTION
The default for the end date is not the same as the start date.

I have guessed what it is here based on other defaults across re-data.

## What
*Describe what the change is solving*
An incorrect piece of documentation

## How
*Describe the solution*
Update the documentation directly