### PR TITLE
generate full manifest during generate overview command

### DIFF
--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -1,3 +1,4 @@
+from audioop import add
 import click
 import subprocess
 import json
@@ -285,6 +286,8 @@ def generate(start_date, end_date, interval, re_data_target_dir, **kwargs):
 
     # run dbt docs generate to generate the a full manifest that contains compiled_path etc
     dbt_docs = ['dbt', 'docs', 'generate']
+    if dbt_vars: dbt_docs.extend(['--vars', yaml.dump(dbt_vars)])
+    add_dbt_flags(dbt_docs)
     dbt_docs_process = subprocess.run(dbt_docs)
     dbt_docs_process.check_returncode()
 

--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -283,6 +283,12 @@ def generate(start_date, end_date, interval, re_data_target_dir, **kwargs):
     completed_process = subprocess.run(command_list)
     completed_process.check_returncode()
 
+    # run dbt docs generate to generate the a full manifest that contains compiled_path etc
+    dbt_docs = ['dbt', 'docs', 'generate']
+    dbt_docs_process = subprocess.run(dbt_docs)
+    dbt_docs_process.check_returncode()
+
+
     dbt_manifest_path = os.path.join(dbt_target_path, 'manifest.json')
     re_data_manifest = os.path.join(re_data_target_path, 'dbt_manifest.json')
     shutil.copyfile(dbt_manifest_path, re_data_manifest)

--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -1,4 +1,3 @@
-from audioop import add
 import click
 import subprocess
 import json

--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -286,7 +286,7 @@ def generate(start_date, end_date, interval, re_data_target_dir, **kwargs):
     # run dbt docs generate to generate the a full manifest that contains compiled_path etc
     dbt_docs = ['dbt', 'docs', 'generate']
     if dbt_vars: dbt_docs.extend(['--vars', yaml.dump(dbt_vars)])
-    add_dbt_flags(dbt_docs)
+    add_dbt_flags(dbt_docs, kwargs)
     dbt_docs_process = subprocess.run(dbt_docs)
     dbt_docs_process.check_returncode()
 


### PR DESCRIPTION
## What
When overview is generated, the manifest file seems to be partially generated. For some features on the observability user interface, we need some information only available in a full manifest.json file.

## How
`dbt docs generate` generates a full manifest.json file so we run that just before copying the manifest file into our target directory.
