### PR TITLE
ensure all keys in json objects are in lower case

### DIFF
--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -15,7 +15,7 @@ from yachalk import chalk
 import yaml
 from re_data.notifications.slack import slack_notify
 from re_data.utils import build_mime_message, parse_dbt_vars, prepare_exported_alerts_per_model, \
-    generate_slack_message, build_notification_identifiers_per_model, send_mime_email
+    generate_slack_message, build_notification_identifiers_per_model, send_mime_email, normalize_re_data_json_export
 from dbt.config.project import Project
 from re_data.tracking import anonymous_tracking
 from re_data.config.utils import read_re_data_config
@@ -304,6 +304,8 @@ def generate(start_date, end_date, interval, re_data_target_dir, **kwargs):
     target_file_path = os.path.join(re_data_target_path, 'index.html')
     shutil.copyfile(OVERVIEW_INDEX_FILE_PATH, target_file_path)
 
+    normalize_re_data_json_export(overview_path)
+
     print(
         f"Generating overview page", chalk.green("SUCCESS")
     )
@@ -416,6 +418,9 @@ def slack(start_date, end_date, webhook_url, subtitle, re_data_target_dir, **kwa
     add_dbt_flags(command_list, kwargs)
     completed_process = subprocess.run(command_list)
     completed_process.check_returncode()
+
+    normalize_re_data_json_export(alerts_path)
+    normalize_re_data_json_export(monitored_path)
 
     with open(alerts_path) as f:
         alerts = json.load(f)

--- a/re_data/utils.py
+++ b/re_data/utils.py
@@ -261,3 +261,17 @@ def send_mime_email(
         server.login(smtp_user, smtp_password)
     server.sendmail(mail_from, mail_to, mime_msg.as_string())
     server.quit()
+
+
+def normalize_re_data_json_export(path: str):
+    """
+    Normalize the data exported from Re.
+    """
+    with open(path, 'r') as f:
+        json_data = json.load(f)
+    
+    normalized_json_data = [{k.lower(): v for k, v in data.items()} for data in json_data]
+
+    # overwrite the original file with the normalized data
+    with open(path, 'w+', encoding='utf-8') as f:
+        json.dump(normalized_json_data, f)


### PR DESCRIPTION
## What
When querying a table and exporting to json file with dbt, there could be cases with inconsistencies in the json keys which map to column names in the db. Particularly in Snowflake, we could have a situation where [QUOTED_IDENTIFIERS_IGNORE_CASE](https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html?_ga=2.67695828.471847891.1650993726-1777166173.1641837216#controlling-case-using-the-quoted-identifiers-ignore-case-parameter) is set at the administrator level. This means that all column names would be capitalized regardless of it being wrapped with double quotes resulting in json keys with capital letters.

## How
Read the json file exported and ensure we have keys as lower case in any command that exports files.
