### PR TITLE
Fixing typo in 'All Good slack alert

### DIFF
--- a/re_data/notifications/slack.py
+++ b/re_data/notifications/slack.py
@@ -174,7 +174,7 @@ def generate_all_good_slack_message(subtitle: str) -> dict:
                 "type": "section",
                 "text": {
                     "type": "plain_text",
-                    "text": "re_data didn't found any alerts at the moment",
+                    "text": "re_data didn't find any alerts at the moment",
                     "emoji": True
                 }
             },


### PR DESCRIPTION
## What
*Describe what the change is solving*
Fixing typo in 'All Good!' slack alert, Issue 340.

## How
*Describe the solution*
Changed 'found' to 'find' in line 177.