### PR TITLE
In order to use a non-ssl port in a smtp notification it is required to use tls

### DIFF
--- a/docs/docs/re_data/getting_started/toy_shop/notifications.md
+++ b/docs/docs/re_data/getting_started/toy_shop/notifications.md
@@ -53,6 +53,7 @@ notifications:
     smtp_user: username
     smtp_password: xxxxx
     use_ssl: true
+    use_tls: false
 ```
 
 Email alerts can now be sent using the command as shown below

--- a/docs/docs/re_data/getting_started/toy_shop/notifications.md
+++ b/docs/docs/re_data/getting_started/toy_shop/notifications.md
@@ -56,6 +56,8 @@ notifications:
     use_tls: false
 ```
 
+If you configure both `use_ssl: true` & `use_tls: true` the tls protocol will be used. TLS will enable you to use different mail ports which SSL does not support on some mail servers, eg `587`.
+
 Email alerts can now be sent using the command as shown below
 ```bash
 re_data notify email \

--- a/docs/docs/re_data/reference/notifications/configuring_channels.md
+++ b/docs/docs/re_data/reference/notifications/configuring_channels.md
@@ -51,6 +51,7 @@ Before you can send alerts via email, you need to have configured an email accou
 - smtp_user: SMTP user to use
 - smtp_password: SMTP password to use
 - use_ssl: Use SSL to connect to SMTP server
+- use_tls: Use TLS to connect to SMTP server
 
 
 ```yaml title="~/.re_data/re_data.yml"
@@ -62,6 +63,7 @@ notifications:
     smtp_user: username
     smtp_password: xxxxx
     use_ssl: true
+    use_tls: false
 ```
 
 Email alerts can now be sent using the command as shown below

--- a/getting_started/toy_shop/re_data.yml
+++ b/getting_started/toy_shop/re_data.yml
@@ -8,3 +8,4 @@ notifications:
     smtp_user: apikey
     smtp_password:
     use_ssl: true
+    use_tls: false

--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -217,7 +217,7 @@ def run(start_date, end_date, interval, full_refresh, **kwargs):
         run_list = ['dbt'] + ['run'] + ['--models'] + ['package:re_data'] + ['--vars'] + [json.dumps(dbt_vars)]
         if for_date == start_date and full_refresh:
             run_list.append('--full-refresh')
-        
+
         add_dbt_flags(run_list, kwargs)
 
         completed_process = subprocess.run(run_list)
@@ -466,7 +466,7 @@ def slack(start_date, end_date, webhook_url, subtitle, re_data_target_dir, selec
     alerts_path = os.path.join(re_data_target_path, 'alerts.json')
     monitored_path = os.path.join(re_data_target_path, 'monitored.json')
     dbt_vars = parse_dbt_vars(kwargs.get('dbt_vars'))
-    
+
     args = {
         'start_date': start_date,
         'end_date': end_date,
@@ -491,7 +491,7 @@ def slack(start_date, end_date, webhook_url, subtitle, re_data_target_dir, selec
     slack_members = build_notification_identifiers_per_model(monitored_list=monitored, channel='slack')
 
     alerts_per_model = prepare_exported_alerts_per_model(alerts=alerts, members_per_model=slack_members, selected_alert_types=selected_alert_types)
-    
+
     alerts_found = False
 
     for model, details in alerts_per_model.items():
@@ -556,19 +556,20 @@ def email(start_date, end_date, re_data_target_dir, select, **kwargs):
     smtp_user = email_config.get('smtp_user')
     smtp_password = email_config.get('smtp_password')
     use_ssl = email_config.get('use_ssl', False)
+    use_tls = email_config.get('use_tls', False)
 
     _, re_data_target_path = get_target_paths(kwargs=kwargs, re_data_target_dir=re_data_target_dir)
     alerts_path = os.path.join(re_data_target_path, 'alerts.json')
     monitored_path = os.path.join(re_data_target_path, 'monitored.json')
     dbt_vars = parse_dbt_vars(kwargs.get('dbt_vars'))
-    
+
     args = {
         'start_date': start_date,
         'end_date': end_date,
         'alerts_path': alerts_path,
         'monitored_path': monitored_path,
     }
-    
+
 
     command_list = ['dbt', 'run-operation', 'export_alerts', '--args', yaml.dump(args)]
     if dbt_vars: command_list.extend(['--vars', yaml.dump(dbt_vars)])
@@ -603,8 +604,9 @@ def email(start_date, end_date, re_data_target_dir, select, **kwargs):
                 smtp_user=smtp_user,
                 smtp_password=smtp_password,
                 use_ssl=use_ssl,
+                use_tls=use_tls
             )
-    
+
     log_notification_status(start_date, end_date, alerts_per_model)
 
 

--- a/re_data/config/validate.py
+++ b/re_data/config/validate.py
@@ -10,6 +10,7 @@ EMAIL_CONFIG_SCHEMA = {
         "smtp_user" : {"type" : "string"},
         "smtp_password" : {"type" : "string"},
         "use_ssl": {"type" : "boolean"},
+        "use_tls": {"type" : "boolean"},
     },
 }
 

--- a/re_data/notifications/email.py
+++ b/re_data/notifications/email.py
@@ -40,7 +40,7 @@ def send_mime_email(
         smtp_port: int,
         smtp_user: str,
         smtp_password: str,
-        use_ssl: bool = True
+        use_ssl: bool = False
     ):
     """
     Send an email using the provided MIME message.
@@ -59,6 +59,7 @@ def send_mime_email(
         server = smtplib.SMTP_SSL(smtp_host, smtp_port)
     else:
         server = smtplib.SMTP(smtp_host, smtp_port)
+        server.starttls()
     if smtp_user and smtp_password:
         server.login(smtp_user, smtp_password)
     server.sendmail(mail_from, mail_to, mime_msg.as_string())

--- a/re_data/notifications/email.py
+++ b/re_data/notifications/email.py
@@ -60,7 +60,7 @@ def send_mime_email(
     if use_tls:
         server = smtplib.SMTP(smtp_host, smtp_port)
         server.starttls()
-    if use_ssl:
+    elif use_ssl:
         server = smtplib.SMTP_SSL(smtp_host, smtp_port)
     else:
         server = smtplib.SMTP(smtp_host, smtp_port)

--- a/re_data/notifications/email.py
+++ b/re_data/notifications/email.py
@@ -40,7 +40,8 @@ def send_mime_email(
         smtp_port: int,
         smtp_user: str,
         smtp_password: str,
-        use_ssl: bool = False
+        use_ssl: bool = True,
+        use_tls: bool = False
     ):
     """
     Send an email using the provided MIME message.
@@ -53,13 +54,16 @@ def send_mime_email(
     :param smtp_user: SMTP user to use
     :param smtp_password: SMTP password to use
     :param use_ssl: Use SSL to connect to SMTP server
+    :param use_tls: Use TLS to connect to SMTP server
     """
 
+    if use_tls:
+        server = smtplib.SMTP(smtp_host, smtp_port)
+        server.starttls()
     if use_ssl:
         server = smtplib.SMTP_SSL(smtp_host, smtp_port)
     else:
         server = smtplib.SMTP(smtp_host, smtp_port)
-        server.starttls()
     if smtp_user and smtp_password:
         server.login(smtp_user, smtp_password)
     server.sendmail(mail_from, mail_to, mime_msg.as_string())


### PR DESCRIPTION
## What

When sending mail notifications with command `re_data notify email` the configuration in `~/.re_data/re_data.yml` always required you to use `use_ssl: true` and this implied the usage of port 465, but this port is [deprecated](https://www.sparkpost.com/blog/what-smtp-port/#:~:text=Port%20587%3A%20The%20standard%20secure,port%20to%20send%20your%20messages.). The usage of this port results in some cases that mail ends up in the spam folder. Using ssl and the default port 587 is not an option. We should start a tsl command before we can use port 587.

## How

Implemented a starttls command before we sign in to the mail server. Since ssl is deprecated I also made sure that this isn't used by default.
