### PR TITLE
add send-all-good/no-send-all-good flag to slack notifier

### DIFF
--- a/re_data/command_line.py
+++ b/re_data/command_line.py
@@ -450,10 +450,18 @@ def serve(port, re_data_target_dir, no_browser, **kwargs):
         Specfy which alert types to generate. This accepts multiple options
         e.g. --select anomaly --select schema_change
     """)
+@click.option(
+    '--send-all-good/--no-send-all-good',
+    default=True,
+    type=click.BOOL,
+    help="""
+        Indicate if a message should be sent if no alerts are found
+        Defaults to true
+    """)
 @add_options(dbt_flags)
 @anonymous_tracking
 @with_version_check
-def slack(start_date, end_date, webhook_url, subtitle, re_data_target_dir, select, **kwargs):
+def slack(start_date, end_date, webhook_url, subtitle, re_data_target_dir, select, send_all_good, **kwargs):
     validate_alert_types(selected_alert_types=select)
     start_date = str(start_date.date())
     end_date = str(end_date.date())
@@ -503,7 +511,7 @@ def slack(start_date, end_date, webhook_url, subtitle, re_data_target_dir, selec
         slack_notify(webhook_url, slack_message)
         alerts_found = True
 
-    if not alerts_found:
+    if not alerts_found and send_all_good:
         slack_message = generate_all_good_slack_message(subtitle)
         slack_notify(webhook_url, slack_message)
 


### PR DESCRIPTION
Add a flag to the slack notifier to indicate if you want to send an 'all good' message

Fixes #373 