### PR TITLE
add message when there are no alerts and option to avoid sending emails

### DIFF
--- a/re_data/templates/email_alert.html
+++ b/re_data/templates/email_alert.html
@@ -109,6 +109,10 @@ table.body .article {
             <table role="presentation" class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background: #ffffff; border-radius: 3px; width: 100%;" width="100%">
               <!-- START MAIN CONTENT AREA -->
 
+              {% if alerts | length == 0 %}
+                  <h3>re_data found no alerts for the time window specified.</h3>
+              {% endif %}
+
               {% for model, details in alerts.items() if model in models_to_notify %}
                 <tr>
                   <td colspan="1" class="wrapper" style="font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 20px;" valign="top">


### PR DESCRIPTION
## What
When no alerts are found within the time window, an empty email is sent. Also users don't have the option to not receive emails when there are no alerts.

## How
- `'--send-all-good/--no-send-all-good',` option was added to the `notify slack` function by @mateuszklimek , I have added support for that flag in the email function as well.
- added a text that shows no alerts where found in the time window instead of an empty email.
