### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/docs/re_data/reference/anomaly_detection.md
+++ b/docs/docs/re_data/reference/anomaly_detection.md
@@ -32,7 +32,7 @@ vars:
 {{
     config(
       re_data_monitored=true,
-      re_data_anomaly_detector={'name': 'z_score', 'threshold': 3} }}
+      re_data_anomaly_detector={'name': 'z_score', 'threshold': 3}
     )
 }}
 
@@ -57,7 +57,7 @@ vars:
 {{
     config(
       re_data_monitored=true,
-      re_data_anomaly_detector={'name': 'modified_z_score', 'threshold': 3} }}
+      re_data_anomaly_detector={'name': 'modified_z_score', 'threshold': 3}
     )
 }}
 
@@ -83,7 +83,7 @@ vars:
 {{
     config(
       re_data_monitored=true,
-      re_data_anomaly_detector={'name': 'boxplot', whisker_boundary_multiplier: 1.5} }}
+      re_data_anomaly_detector={'name': 'boxplot', whisker_boundary_multiplier: 1.5}
     )
 }}
 

--- a/docs/docs/re_data/reference/config.mdx
+++ b/docs/docs/re_data/reference/config.mdx
@@ -35,7 +35,7 @@ re_data dbt native cofiguration follows the same rules as dbt configuration, con
       re_data_columns=['amount', 'status'],
       re_data_metrics_groups=['table_metrics', 'column_metrics'],
       re_data_metrics={'table': ['orders_obove_100'], 'column': { 'status': ['distinct_values'],
-      re_data_anomaly_detector={'name': 'modified_z_score', 'threshold': 3.0} }},
+      re_data_anomaly_detector={'name': 'modified_z_score', 'threshold': 3.0},
       re_data_owners=['datateam']
     )
 }}

--- a/docs/docs/re_data/reference/config.mdx
+++ b/docs/docs/re_data/reference/config.mdx
@@ -35,7 +35,7 @@ re_data dbt native cofiguration follows the same rules as dbt configuration, con
       re_data_columns=['amount', 'status'],
       re_data_metrics_groups=['table_metrics', 'column_metrics'],
       re_data_metrics={'table': ['orders_obove_100'], 'column': { 'status': ['distinct_values'],
-      re_data_anomaly_detector={'name': 'modified_z_score', 'threshold': 3.0},
+      re_data_anomaly_detector={'name': 'modified_z_score', 'threshold': 3.0} }},
       re_data_owners=['datateam']
     )
 }}
@@ -309,3 +309,4 @@ This is used to enable storing sample data of monitored tables.
 ### re_data:owners_config
 
 Variable to configure owners for your data.  See [re_data notifications](/docs/re_data/reference/notifications/configuring_owners) for more details.
+


### PR DESCRIPTION
## What
There is a typo in the documentation which this PR will fix.

## How
Removes excess curly braces at the end of certain config blocks.
