### PR TITLE
Makefile and Improved CI

### DIFF
--- a/.github/workflows/es-lint.yml
+++ b/.github/workflows/es-lint.yml
@@ -2,19 +2,21 @@ name: ES Lint
 
 on: push
 
+env:
+  NODE_VERSION: 16.17.0
+
 jobs:
   run-linters:
     name: Run linters
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 16.13.0
+          node-version: ${{ env.NODE_VERSION }}
 
       # ESLint and Prettier must be in `package.json`
       - name: Install Node.js dependencies

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -2,16 +2,19 @@ name: Generate docusaurus documentation
 
 on: push
 
+env:
+  NODE_VERSION: 16.17.0
+
 jobs:
   generate-docs:
     runs-on: ubuntu-latest
-    steps:        
+    steps:
       - name: Check out
         uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.17.0'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
@@ -30,6 +33,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
+        if: ${{ !env.ACT }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-ui.yml
+++ b/.github/workflows/generate-ui.yml
@@ -21,6 +21,8 @@ env:
   BIGQUERY_TESTING_CLIENT_X509_CERT_URL: ${{ secrets.BIGQUERY_TESTING_CLIENT_X509_CERT_URL }}
   RE_DATA_SEND_ANONYMOUS_USAGE_STATS: 0
   DBT_VERSION: 1.7
+  NODE_VERSION: 16.17.0
+  PYTHON_VERSION: "3.8.x"
 
 jobs:
   generate-ui:
@@ -46,7 +48,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8.x"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
@@ -88,7 +90,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "16.13.0"
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Set homepage in package.json
         if: ${{ !env.ACT }}
@@ -108,7 +110,7 @@ jobs:
         env:
           PUBLIC_URL: https://${{env.GITHUB_REPOSITORY_OWNER_PART_SLUG}}.github.io/${{env.GITHUB_REPOSITORY_NAME_PART_SLUG}}/ui-${{env.GITHUB_REF_SLUG}}
 
-      - name: Generate re_data artefacts
+      - name: Generate re_data artifacts
         working-directory: ./getting_started/toy_shop
         run: |
           re_data overview generate --start-date 2021-01-01 --profiles-dir ${{env.DBT_PROFILES_DIR}} --project-dir ./ --profile toy_shop_postgres
@@ -123,7 +125,7 @@ jobs:
 
   generate-ui-other-dbs:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.repository == 're-data/re-data'
+    if: github.event_name == 'push' && github.repository == 're-data/re-data' && github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
@@ -134,7 +136,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8.x"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
@@ -199,7 +201,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "16.13.0"
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Set homepage in package.json
         if: ${{ !env.ACT }}
@@ -227,7 +229,7 @@ jobs:
         run: sleep 60
         shell: bash
 
-      - name: Generate re_data artefacts
+      - name: Generate re_data artifacts
         working-directory: ./getting_started/toy_shop
         run: |
           re_data overview generate --start-date 2021-01-01 --profiles-dir ${{env.DBT_PROFILES_DIR}} --project-dir ./ --profile toy_shop_${{ matrix.database }}
@@ -242,18 +244,18 @@ jobs:
 
   clean-up-schemas:
     runs-on: ubuntu-latest
-    if: github.event_name == 'delete' && github.repository == 're-data/re-data'
+    if: github.event_name == 'delete' && github.repository == 're-data/re-data' && github.ref == 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:
         database: [snowflake, bigquery, redshift]
-    steps:        
+    steps:
       - name: Check out
         uses: actions/checkout@v2
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8.x"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
@@ -276,7 +278,6 @@ jobs:
   clean-up-deployment:
     runs-on: ubuntu-latest
     if: github.event_name == 'delete'
-    
     steps:        
       - name: Check out
         uses: actions/checkout@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,25 +2,32 @@ name: Upload Python Package
 
 on: push
 
+env:
+  PYTHON_VERSION: "3.8.x"
+
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+
+    - name: Check out
+      uses: actions/checkout@v2
+
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: ${{ env.PYTHON_VERSION }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build
+
     - name: Build package
       run: python -m build
       
     - name: Publish distribution 📦 to Test PyPI
+      if: ${{ !env.ACT }}
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__
@@ -29,7 +36,7 @@ jobs:
         skip_existing: true
         
     - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+      if: startsWith(github.ref, 'refs/tags') && !env.ACT
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# RE Data Contributing Guidelines
+
+Thank you for contributing to RE Data! We value your contributions and will do our best to make sure Issues and PRs are reviewed in a timely fashion.
+
+## Project Setup
+
+The RE Data Framework is spread across two separate GitHub repos, [re-data](https://github.com/re-data/re-data) which hosts the [RE Data Python package](https://pypi.org/project/re-data) and [dbt-re-data](https://github.com/re-data/dbt-re-data) which hosts the [RE Data DBT package](https://hub.getdbt.com/re-data/re_data/latest).
+
+The re-data Python library runs the re_data CLI allowing you to run commands like `re_data overview generate` and also houses the RE Data UI.
+
+The dbt-re-data repo only houses the DBT package. Note the re-data Toy Shop tutorial in the re-data repo imports the RE Data DBT package directly from the `main` branch of the dbt-re-data GitHub repo in the [`getting_started/toy_shop/packages.yml`](getting_started/toy_shop/packages.yml) file.
+
+Since these repos are interdependent many changes to one repo will require a change in the other. If you find yourself hopping between repos often one trick is to import the dbt-re-data repo you have locally into the [`getting_started/toy_shop/packages.yml`](getting_started/toy_shop/packages.yml) instead of the version hosted on GitHub. See the [DBT Docs here](https://docs.getdbt.com/docs/build/packages#local-packages) for how to configure local packages in the profiles.yml.
+
+## Developing Locally
+
+### Installations
+
+- [make](https://www.gnu.org/software/make)
+- [act](https://github.com/nektos/act#installation)
+- [Docker](https://docs.docker.com/engine/install)
+
+This repo has a [Makefile](Makefile) that can be used to run most CLI commands you will need while developing. The first couple commands of the Makefile use [act](https://github.com/nektos/act#installation) to run the GitHub Actions CI Jobs locally. 
+
+RE Data runs locally on a Postgres database that is spun up on your local machine using Docker. RE Data supports several other data warehouses that cannot be spun up locally thus any CI jobs that involve making a connection to BigQuery, Redshift, or Snowflake will not run locally and will only run as part of the CI in GitHub.
+
+The middle section of the Makefile is used to run Postgres locally and run the example DBT project for the Toy Shop in the [`getting_started/toy_shop`](getting_started/toy_shop) directory. After running `make setup-toy-shop` there will be a few JSON files in the `target/re_data` directory in [`getting_started/toy_shop`](getting_started/toy_shop). These files are the RE Data artifacts that are read into the UI. Run `make copy-artifacts` to copy these files to the [`re_data_ui/public`](re_data_ui/public) directory so that the UI can read them in.
+
+The last part of the Makefile helps you to spin the RE Data UI up locally. The RE Data UI is essentially a static React app. It reads in the RE Data artifacts from the public folder then displays them in various visuals.
+
+Once all of your changes are made, aside from running all of the GitHub Actions CI jobs you can set up the Toy Shop and run the UI. The UI should closely match the [hosted Demo UI](https://docs.getre.io/ui-latest) plus any changes you've made.
+
+### Versions Should Match
+
+There are different versions of DBT, Python and Node throughout both repos make sure they all match. Below are the places to double check versions match:
+
+- The `env` variables in the GitHub Actions files
+- Any `packages.yml` files
+- Any `requirements.txt` files
+
+## [dbt-re-data](https://github.com/re-data/dbt-re-data) Repo
+
+The dbt-re-data repo also contains a Makefile that is used to run both of the GitHub Actions CI jobs. The re-data repo imports the dbt-re-data repo as a dependency, but not vice versa. The dbt-re-data repo has several PyTests that essentially run the same workflow of setting up the Toy Shop in the background.
+
+## Issues and Pull Requests
+
+All Issues for both repos are held in the [re-data](https://github.com/re-data/re-data/issues) repo. Most issues are either a Bug or a Feature. Please make an Issue and fill out the template before making a Pull Request. We will try to get your Pull Requests merged in a timely fashion. Always feel free to reach out in [Slack](https://join.slack.com/t/re-data/shared_invite/zt-vkauq1y8-tL4R4_H5nZoVvyXyy0hdug).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,79 @@
+
+# Maybe change this if you are not running on a Mac
+CONTAINER_ARCH = linux/amd64 
+
+.PHONY: help run-all-ci run-linters generate-docs generate-ui python-publish run-postgres setup-toy-shop copy-artifacts install-frontend run-frontend
+
+help:
+	$(info ${HELP_MESSAGE})
+	@exit 0
+
+
+# Run GitHub Actions CI jobs locally
+run-all-ci: run-linters generate-docs generate-ui python-publish
+	@echo "All CI steps completed."
+
+run-linters:
+	@echo "Running run-linters job..."
+	act -j run-linters --container-architecture $(CONTAINER_ARCH)
+
+generate-docs:
+	@echo "Running generate-docs job..."
+	act -j generate-docs --container-architecture $(CONTAINER_ARCH)
+
+generate-ui:
+	@echo "Running generate-ui job..."
+	act -j generate-ui --container-architecture $(CONTAINER_ARCH)
+
+python-publish:
+	@echo "Running deploy job..."
+	act -j deploy --container-architecture $(CONTAINER_ARCH)
+
+
+# Run Toy Shop demo locally
+run-postgres:
+	@echo "Running Postgres locally using Docker..."
+	docker run --name postgres-container \
+		-e POSTGRES_PASSWORD=postgres \
+		-p 5432:5432 \
+		--health-cmd="pg_isready" \
+		--health-interval=10s \
+		--health-timeout=5s \
+		--health-retries=5 postgres
+
+setup-toy-shop:
+	@echo "Filling Postgres local database with Toy Shop sample data..."
+	( cd getting_started/toy_shop && pip install dbt-postgres && dbt deps && DBT_PROFILES_DIR="./" ./setup_toy_shop.sh toy_shop_postgres )
+
+
+# Run UI locally
+copy-artifacts:
+	@echo "Copying re-data artifact files to frontend public folder..."
+	cp getting_started/toy_shop/target/re_data/*.json re_data_ui/public/
+
+install-frontend:
+	@echo "Installing UI dependencies..."
+	( cd re_data_ui && yarn install )
+
+run-frontend: install-frontend
+	@echo "Running RE Data UI..."
+	( cd re_data_ui && npm start )
+
+
+define HELP_MESSAGE
+Usage: $ make [TARGETS]
+
+TARGETS
+	help                    Shows this help message
+	run-all-ci              Runs all CI steps
+	run-linters             Runs run-linters job
+	generate-docs           Runs generate-docs job
+	generate-ui             Runs generate-ui job
+	python-publish          Runs deploy job
+	run-postgres            Run Postgres locally using Docker
+	setup-toy-shop          Fill Postgres local database with Toy Shop sample data, requires make run-postgres first
+	copy-artifacts          Copy re-data artifact files to frontend public folder
+	install-frontend        Install UI dependencies
+	run-frontend            Run RE Data UI
+
+endef

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img alt="Logo" width=18% src="static/logo/redata_logo_cicle.svg"/>
 </p>
 <p align="center">
-<a href="https://www.getre.io/slack"><img alt="Slack" src="https://img.shields.io/badge/chat-slack-blue.svg"/></a>
+<a href="https://join.slack.com/t/re-data/shared_invite/zt-vkauq1y8-tL4R4_H5nZoVvyXyy0hdug"><img alt="Slack" src="https://img.shields.io/badge/chat-slack-blue.svg"/></a>
 <img alt="Last commit" src="https://img.shields.io/github/last-commit/redata-team/redata"/>
 </p>
 
@@ -28,7 +28,7 @@ Check out our **[live demo](https://docs.getre.io/ui-latest)** of what re_data c
 
 # Support
 
-If you like what we are building, support us! Star ⭐ [re_data](https://github.com/re-data/re-data) on Github. We will also plant a tree 🌳 for every star we get, so you will also support our planet 🌍 😊
+If you like what we are building, support us! Star ⭐ [re_data](https://github.com/re-data/re-data) on Github.
 
 # License
 re_data is licensed under the MIT license. See the [LICENSE](LICENSE) file for licensing information.
@@ -37,5 +37,4 @@ re_data is licensed under the MIT license. See the [LICENSE](LICENSE) file for l
 
 We love all contributions :heart_eyes: bigger and smaller.
 
-Check out the current list of issues [here](https://github.com/re-data/re-data/issues) and see if you like anything from there. Also, feel welcome to join our [Slack](https://www.getre.io/slack) and suggest ideas or set up a live session [here](https://calendly.com/mateuszklimek/30min). 
-
+Check out the current list of issues [here](https://github.com/re-data/re-data/issues) and see our [Contributing Guide](CONTRIBUTING.md). Also, feel welcome to join our [Slack](https://join.slack.com/t/re-data/shared_invite/zt-vkauq1y8-tL4R4_H5nZoVvyXyy0hdug) and suggest ideas or set up a live session [here](https://calendly.com/mateuszklimek/30min).

--- a/getting_started/toy_shop/.gitignore
+++ b/getting_started/toy_shop/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 dbt_packages/
 logs/
+.user.yml
+package-lock.yml

--- a/getting_started/toy_shop/packages.yml
+++ b/getting_started/toy_shop/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=1.0.0", "<1.1.0"]
+    version: [">=1.0.0", "<1.2.0"]
 
   - git: "https://github.com/re-data/dbt-re-data.git"
     revision: main


### PR DESCRIPTION
## What
- CI should runner smoother now with less unnecessary runs
- Local development should be easier now
- Improved documentation

## How
- Jobs that run commands on data warehouses that aren't Postgres now only run when a PR is merged to the `main` branch
- Makefile runs all most CLI commands for development and uses [act](https://github.com/nektos/act) to run the GitHub Actions files locally

